### PR TITLE
Adds a config option to ignore entities

### DIFF
--- a/src/main/java/solarcraft/core/SC_Settings.java
+++ b/src/main/java/solarcraft/core/SC_Settings.java
@@ -24,4 +24,5 @@ public class SC_Settings
 	public static float gravityFact = 1F;
 	public static boolean spaceSkybox = true;
 	public static boolean generateWormholes = true;
+	public static String[] ignoredEntites = new String[] {};
 }

--- a/src/main/java/solarcraft/handlers/ConfigHandler.java
+++ b/src/main/java/solarcraft/handlers/ConfigHandler.java
@@ -43,7 +43,12 @@ public class ConfigHandler
 	        "minecraft:stained_hardened_clay:1",
 	        "minecraft:stained_hardened_clay"
 		};
-		
+
+		String[] entityIgnoreDefault = new String[] {
+			"Bat",
+			"Chicken"
+		};
+
 		SC_Settings.asteroidWeight = config.getFloat("Asteroid Weight", Configuration.CATEGORY_GENERAL, -35, -100F, 80F, "Weighted density of asteroids/landmasses");
 		SC_Settings.spawnIsland = config.getFloat("Spawn Size", Configuration.CATEGORY_GENERAL, 24F, 16F, 1024F, "Size of the spawn island (Always created at maximum weight & size)");
 		SC_Settings.genGrass = config.getBoolean("Use Old Biomes", Configuration.CATEGORY_GENERAL, false, "Use the overworlds old biomes instead. Makes for a good 'blown apart world' look");

--- a/src/main/java/solarcraft/handlers/ConfigHandler.java
+++ b/src/main/java/solarcraft/handlers/ConfigHandler.java
@@ -61,7 +61,8 @@ public class ConfigHandler
 		SC_Settings.spaceSkybox = config.getBoolean("Space Skybox", Configuration.CATEGORY_GENERAL, true, "Replaces the normal overworld skybox with only stars");
 		SC_Settings.generateWormholes = config.getBoolean("Generate Wormholes", Configuration.CATEGORY_GENERAL, true, "Generates natural wormholes in all worlds (fairly rare)");
 		SC_Settings.spaceBiomeID = config.getInt("Space Biome ID", Configuration.CATEGORY_GENERAL, 24, 0, BiomeGenBase.getBiomeGenArray().length - 1, "The biome ID used in the scorched area of space");
-		
+		SC_Settings.ignoredEntites = config.getStringList("Ignored Entites", Configuration.CATEGORY_GENERAL, entityIgnoreDefault, "Set which Entities should be ignored in gravity processing");
+
 		if(!config.hasCategory("Planets"))
 		{
 			config.getInt("Biome ID", "Planets.default", BiomeGenBase.forest.biomeID, 0, BiomeGenBase.getBiomeGenArray().length - 1, "The planet's biome");

--- a/src/main/java/solarcraft/handlers/EventHandler.java
+++ b/src/main/java/solarcraft/handlers/EventHandler.java
@@ -2,6 +2,7 @@ package solarcraft.handlers;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityFlying;
+import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
@@ -176,7 +177,7 @@ public class EventHandler
 				boolean ignoreThisEntity = false;
 
 				for (String entityName : SC_Settings.ignoredEntites) {
-					if (entity.getClass().getName().equals(entityName))
+					if (EntityList.getEntityString(entity).equals(entityName))
 						ignoreThisEntity = true;
 				}
 

--- a/src/main/java/solarcraft/handlers/EventHandler.java
+++ b/src/main/java/solarcraft/handlers/EventHandler.java
@@ -190,9 +190,10 @@ public class EventHandler
 				Entity entity = (Entity)entry;
 
 				boolean ignoreThisEntity = false;
+				String entityString = EntityList.getEntityString(entity);
 
 				for (String entityName : SC_Settings.ignoredEntites) {
-					if (EntityList.getEntityString(entity).equals(entityName))
+					if (entityString.equals(entityName))
 					{
 						ignoreThisEntity = true;
 						break;

--- a/src/main/java/solarcraft/handlers/EventHandler.java
+++ b/src/main/java/solarcraft/handlers/EventHandler.java
@@ -188,7 +188,10 @@ public class EventHandler
 
 				for (String entityName : SC_Settings.ignoredEntites) {
 					if (EntityList.getEntityString(entity).equals(entityName))
+					{
 						ignoreThisEntity = true;
+						break;
+					}
 				}
 
 				if (ignoreThisEntity)

--- a/src/main/java/solarcraft/handlers/EventHandler.java
+++ b/src/main/java/solarcraft/handlers/EventHandler.java
@@ -55,7 +55,17 @@ public class EventHandler
 	@SubscribeEvent
 	public void onLivingUpdate(LivingUpdateEvent event)
 	{
-		if(event.entityLiving.dimension == 0 && !event.entityLiving.onGround && !(event.entityLiving.isInWater() || event.entityLiving.handleLavaMovement()) && !(event.entityLiving instanceof EntityFlying) && !(event.entityLiving instanceof EntityPlayer && ((EntityPlayer)event.entityLiving).capabilities.isFlying))
+		boolean ignoreThisEntity = false;
+
+		for (String entityName : SC_Settings.ignoredEntites) {
+			if (EntityList.getEntityString(entity).equals(entityName))
+			{
+				ignoreThisEntity = true;
+				break;
+			}
+		}
+
+		if(event.entityLiving.dimension == 0 && !event.entityLiving.onGround && !(event.entityLiving.isInWater() || event.entityLiving.handleLavaMovement()) && !(event.entityLiving instanceof EntityFlying) && !(event.entityLiving instanceof EntityPlayer && ((EntityPlayer)event.entityLiving).capabilities.isFlying) && !ignoreThisEntity)
 		{
 			event.entityLiving.addVelocity(0D, SC_Settings.gravityFact * 0.07D, 0D);
 			

--- a/src/main/java/solarcraft/handlers/EventHandler.java
+++ b/src/main/java/solarcraft/handlers/EventHandler.java
@@ -57,13 +57,18 @@ public class EventHandler
 	{
 		boolean ignoreThisEntity = false;
 
-		for (String entityName : SC_Settings.ignoredEntites) {
-			if (EntityList.getEntityString(entity).equals(entityName))
-			{
-				ignoreThisEntity = true;
-				break;
-			}
-		}
+		String entitiyString = EntityList.getEntityString(event.entity);
+
+        if (entitiyString != null)
+        {
+            for (String entityName : SC_Settings.ignoredEntites) {
+                if (entitiyString.equals(entityName))
+                {
+                    ignoreThisEntity = true;
+                    break;
+                }
+            }
+        }
 
 		if(event.entityLiving.dimension == 0 && !event.entityLiving.onGround && !(event.entityLiving.isInWater() || event.entityLiving.handleLavaMovement()) && !(event.entityLiving instanceof EntityFlying) && !(event.entityLiving instanceof EntityPlayer && ((EntityPlayer)event.entityLiving).capabilities.isFlying) && !ignoreThisEntity)
 		{

--- a/src/main/java/solarcraft/handlers/EventHandler.java
+++ b/src/main/java/solarcraft/handlers/EventHandler.java
@@ -172,7 +172,17 @@ public class EventHandler
 				}
 				
 				Entity entity = (Entity)entry;
-				
+
+				boolean ignoreThisEntity = false;
+
+				for (String entityName : SC_Settings.ignoredEntites) {
+					if (entity.getClass().getName().equals(entityName))
+						ignoreThisEntity = true;
+				}
+
+				if (ignoreThisEntity)
+					continue;
+
 				if(entity.dimension == 0 && !entity.onGround && !(entity.isInWater() || entity.handleLavaMovement()))
 				{
 					entity.motionY = MathHelper.clamp_double(entity.motionY, -3D, 3D); // Make sure entity isn't already too fast for ZeroG

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -7,7 +7,7 @@
   "mcversion": "${mcversion}",
   "url": "",
   "updateUrl": "",
-  "authorList": ["Funwayguy","Darkosto","tyra314"],
+  "authorList": ["Funwayguy","Darkosto"],
   "credits": "",
   "logoFile": "",
   "screenshots": [],

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -7,7 +7,7 @@
   "mcversion": "${mcversion}",
   "url": "",
   "updateUrl": "",
-  "authorList": ["Funwayguy","Darkosto"],
+  "authorList": ["Funwayguy","Darkosto","tyra314"],
   "credits": "",
   "logoFile": "",
   "screenshots": [],


### PR DESCRIPTION
All entity class names given in the new config option will be ignored in
gravity calculations.

Note: As I'm not very familiar with Java, there might be better and/or faster ways to detect if a given entity matches one of the entity types, which should be ignored.
